### PR TITLE
Code uses 10 seconds as the period to repeat the request to the server.

### DIFF
--- a/LocationTracker/MainPage.xaml.cs
+++ b/LocationTracker/MainPage.xaml.cs
@@ -229,7 +229,7 @@ namespace LocationTracker
                     this.NotifyUser("Extended execution allowed. Please navigate away from this app.", NotifyType.StatusMessage);
                     session = newSession;
                     Geolocator geolocator = await StartLocationTrackingAsync();
-                    periodicTimer = new Timer(OnTimer, geolocator, TimeSpan.FromSeconds(interval), TimeSpan.FromSeconds(10));
+                    periodicTimer = new Timer(OnTimer, geolocator, TimeSpan.FromSeconds(interval), TimeSpan.FromSeconds(interval));
                     break;
 
                 default:


### PR DESCRIPTION
The app uses 10 seconds as the interval of running the tracking instead of the variable set in the UI which is only used for the time before the 1st run.